### PR TITLE
feat: add config for Iceman v4.21128 with autopwn and fchk commands

### DIFF
--- a/config/config.qrc
+++ b/config/config.qrc
@@ -4,5 +4,6 @@
         <file>config_rrgv4.13441.json</file>
         <file>config_rrgv4.15864.json</file>
         <file>config_rrgv4.16717.json</file>
+        <file>config_rrgv4.21128.json</file>
     </qresource>
 </RCC>

--- a/config/config_rrgv4.21128.json
+++ b/config/config_rrgv4.21128.json
@@ -1,0 +1,205 @@
+{
+    "//": "Based on Proxmark3 rrg repo v4.21128 (Permafrost), 2026-02-25",
+    "//": "You can change this file if the command format of client changes",
+    "mifare classic": {
+        "nested": {
+            "cmd": "hf mf nested --<card type> --blk <block> -<key type> -k <key>",
+            "static cmd": "hf mf staticnested --<card type> --blk <block> -<key type> -k <key>",
+            "card type": {
+                "mini": "mini",
+                "1k": "1k",
+                "2k": "2k",
+                "4k": "4k"
+            },
+            "key type": {
+                "A": "a",
+                "B": "b"
+            },
+            "key pattern": "\\s*\\d{3}\\s*\\|\\s*\\d{3}\\s*\\|\\s*.+?\\s*\\|\\s*.+?\\s*\\|\\s*.+?\\s*\\|\\s*.+?\\s*$",
+            "key A index": 2,
+            "key B index": 4
+        },
+        "autopwn": {
+            "cmd": "hf mf autopwn --<card type>",
+            "card type": {
+                "mini": "mini",
+                "1k": "1k",
+                "2k": "2k",
+                "4k": "4k"
+            },
+            "key pattern": "\\s*\\d{3}\\s*\\|\\s*\\d{3}\\s*\\|\\s*.+?\\s*\\|\\s*.+?\\s*\\|\\s*.+?\\s*\\|\\s*.+?\\s*$",
+            "key A index": 2,
+            "key B index": 4
+        },
+        "check": {
+            "cmd": "hf mf fchk --<card type>",
+            "card type": {
+                "mini": "mini",
+                "1k": "1k",
+                "2k": "2k",
+                "4k": "4k"
+            },
+            "key pattern": "\\s*\\d{3}\\s*\\|\\s*\\d{3}\\s*\\|\\s*.+?\\s*\\|\\s*.+?\\s*\\|\\s*.+?\\s*\\|\\s*.+?\\s*$",
+            "key A index": 2,
+            "key B index": 4
+        },
+        "info": {
+            "cmd": "hf 14a info -nsv",
+            "basic cmd": "hf 14a info"
+        },
+        "sniff": {
+            "cmd": "hf sniff"
+        },
+        "sniff 14a": {
+            "cmd": "hf 14a sniff"
+        },
+        "list": {
+            "cmd": "trace list -t mf"
+        },
+        "dump": {
+            "cmd": "hf mf dump --<card type>",
+            "card type": {
+                "mini": "mini",
+                "1k": "1k",
+                "2k": "2k",
+                "4k": "4k"
+            }
+        },
+        "restore": {
+            "cmd": "hf mf restore --<card type> --force",
+            "card type": {
+                "mini": "mini",
+                "1k": "1k",
+                "2k": "2k",
+                "4k": "4k"
+            }
+        },
+        "emulator wipe": {
+            "cmd": "hf mf eclr"
+        },
+        "Magic Card wipe": {
+            "cmd": "hf mf cwipe"
+        },
+        "emulator read block": {
+            "cmd": "hf mf egetblk --blk <block>",
+            "data pattern": "([0-9a-fA-F]{2} ){15}[0-9a-fA-F]{2}"
+        },
+        "Magic Card read block": {
+            "cmd": "hf mf cgetblk --blk <block>",
+            "data pattern": "([0-9a-fA-F]{2} ){15}[0-9a-fA-F]{2}"
+        },
+        "normal read block": {
+            "cmd": "hf mf rdbl --blk <block> -<key type> -k <key>",
+            "key type": {
+                "A": "a",
+                "B": "b"
+            },
+            "data pattern": "([0-9a-fA-F]{2} ){15}[0-9a-fA-F]{2}"
+        },
+        "darkside": {
+            "cmd": "hf mf darkside"
+        },
+        "save sniff": {
+            "cmd": "trace save -f <filename>",
+            "path cmd": "prefs show",
+            "path pattern": "trace save path\\.+\\s*(.+)$"
+        },
+        "load sniff": {
+            "cmd": "trace load -f <filename>",
+            "show cmd": "trace list --buffer -t mf"
+        },
+        "hardnested": {
+            "cmd": "hf mf hardnested --blk <known key block> -<known key type> -k <known key> --tblk <target key block> --t<target key type>",
+            "known key type": {
+                "A": "a",
+                "B": "b"
+            },
+            "target key type": {
+                "A": "a",
+                "B": "b"
+            }
+        },
+        "normal read sector": {
+            "cmd": "hf mf rdsc --sec <sector> -<key type> -k <key>",
+            "key type": {
+                "A": "a",
+                "B": "b"
+            },
+            "data pattern": "([0-9a-fA-F]{2} ){15}[0-9a-fA-F]{2}"
+        },
+        "Magic Card read sector": {
+            "cmd": "hf mf cgetsc --sec <sector>",
+            "data pattern": "([0-9a-fA-F]{2} ){15}[0-9a-fA-F]{2}"
+        },
+        "normal write block": {
+            "cmd": "hf mf wrbl --blk <block> -<key type> -k <key> -d <data> --force",
+            "key type": {
+                "A": "a",
+                "B": "b"
+            },
+            "failed flag": ["fail", "error"]
+        },
+        "Magic Card write block": {
+            "cmd": "hf mf csetblk --blk <block> -d <data>",
+            "failed flag": ["fail", "error"]
+        },
+        "emulator write block": {
+            "cmd": "hf mf esetblk --blk <block> -d <data>"
+        },
+        "Magic Card lock": {
+            "cmd": "hf 14a raw ",
+            "sequence": [
+                "-ak -b 7 40",
+                "-ak 43",
+                "-ak E0 00 39 F7",
+                "-ak E1 00 E1 EE",
+                "-ak 85 00 00 00 00 00 00 00 00 00 00 00 00 00 00 08 18 47",
+                "-a 52"
+            ]
+        },
+        "Magic Card set parameter": {
+            "cmd": "hf mf csetuid --uid <uid> --atqa <atqa> --sak <sak>"
+        }
+    },
+    "lf": {
+        "read": {
+            "cmd": "lf read -v",
+            "show cmd": "data plot"
+        },
+        "sniff": {
+            "cmd": "lf sniff -v",
+            "show cmd": "data plot"
+        },
+        "search": {
+            "cmd": "lf search -u"
+        },
+        "tune": {
+            "cmd": "lf tune --divisor <divisor>"
+        },
+        "get config": {
+            "cmd": "hw status",
+            "field start": "LF Sampling config",
+            "field end": "\\[#\\] \\S",
+            "divisor": {"flag": "divisor", "pattern": "\\d+"},
+            "bits per sample": {"flag": "bits per sample", "pattern": "\\d+"},
+            "decimation": {"flag": "decimation", "pattern": "\\d+"},
+            "averaging": {"flag": "averaging", "pattern": "\\d+", "replace": {"yes": "1", "no": "0", "Yes": "1", "No": "0"}},
+            "trigger threshold": {"flag": "trigger threshold", "pattern": "\\d+"},
+            "samples to skip": {"flag": "samples to skip", "pattern": "\\d+"}
+        },
+        "set config": {
+            "cmd": "lf config --divisor <divisor> --bps <bits per sample> --dec <decimation> --avg <averaging> --trig <trigger threshold> --skip <samples to skip>",
+            "divisor cmd": "hw setlfdivisor -d <divisor>"
+        }
+    },
+    "t55xx": {
+        "clone em410x": {
+            "read": "lf em 410x reader",
+            "successful read flag": "EM 410x ID",
+            "pattern": "EM 410x ID\\s*\\K[0-9a-fA-F]{10}",
+            "clone cmd": "lf em 410x clone --id <id> <type>",
+            "t5555 flag": "--q5",
+            "t55x7 flag": ""
+        }
+    }
+}


### PR DESCRIPTION
## Summary\n\nAdds a new JSON config file (`config_rrgv4.21128.json`) targeting the latest Iceman release (v4.21128 \"Permafrost\", 2026-02-25).\n\n### Changes\n\n**New config: `config/config_rrgv4.21128.json`**\n- Based on `config_rrgv4.16717.json` with updates for current Iceman syntax\n- Added `hf mf autopwn` command — the primary key recovery workflow since ~v4.14000, which was the most requested missing command (#38)\n- Updated `check` to use `hf mf fchk` (fast key check) instead of `hf mf chk` for better performance\n- All other commands verified against current Iceman `help` output\n\n**Updated: `config/config.qrc`**\n- Added `config_rrgv4.21128.json` to the Qt resource list\n\n### Audit Notes\n\nThe existing RRG configs (v4.13441, v4.15864, v4.16717) are correct for their target versions. The `config_official.json` targets PM3 official v3.1.0 which uses positional args — this is intentional for users with the official firmware.\n\n### Addresses\n- #65 — Need update to actual version of pm3 command\n- #68 — Need update (general)\n- #38 — GUI missing support for autopwn\n\n### Testing\n\nCommand strings verified against `proxmark3 --help` output from Iceman master a72f66b (v4.21128)."